### PR TITLE
修复 rangelength 规则

### DIFF
--- a/src/form/validator.ts
+++ b/src/form/validator.ts
@@ -30,7 +30,7 @@ export default {
         if (val.length > maxlen) return sprintf(r.message || defaultMessage.maxlength, maxlen)
     },
     rangelength: (r, val) => {
-        const range = r.range
+        const range = r.rangelength
         val = val || ''
         if (val.length > range[1] || val.length < range[0]) return sprintf(r.message || defaultMessage.rangelength, range[0], range[1])
     },


### PR DESCRIPTION
按照文档中配置的如下 rangelength 规则会报错，本 PR 修复了这个问题
```
{
    name: "fieldName",
    rules: {
        rangelength: [2, 6]
    }
}
```