### PR TITLE
修复 navigation-bar 在旧版本微信高度错误问题

### DIFF
--- a/src/navigation-bar/navigation-bar.ts
+++ b/src/navigation-bar/navigation-bar.ts
@@ -54,18 +54,14 @@ Component({
     displayStyle: ''
   },
   attached() {
-    const isSupport = !!wx.getMenuButtonBoundingClientRect
-    const rect = wx.getMenuButtonBoundingClientRect ? wx.getMenuButtonBoundingClientRect() : null
     wx.getSystemInfo({
         success: res => {
           const ios = !!(res.system.toLowerCase().search('ios') + 1)
           this.setData({
-            ios,
-            statusBarHeight: res.statusBarHeight,
-            innerWidth: isSupport ? `width:${rect.left}px` : '',
-            innerPaddingRight: isSupport ? `padding-right:${res.windowWidth - rect.left}px` : '',
-            leftWidth: isSupport ? `width:${res.windowWidth - rect.left}px` : '',
+            ios: ios,
+            statusBarHeight: res.statusBarHeight
           })
+          this.setStyle(res)
       },
     })
   },
@@ -73,6 +69,28 @@ Component({
    * 组件的方法列表
    */
   methods: {
+    setStyle(res) {
+      var isSupport = !!wx.getMenuButtonBoundingClientRect
+      if (isSupport) {
+        var rect = wx.getMenuButtonBoundingClientRect()
+        this.setData({
+          innerWidth: 'width:' + rect.left + 'px',
+          innerPaddingRight: 'padding-right:' + (res.windowWidth - rect.left) + 'px',
+          leftWidth: 'width:' + (res.windowWidth - rect.left) + 'px'
+        })
+        if (rect.left === 0) {
+          setTimeout(() => {
+            this.setStyle(res)
+          }, 100)
+        }
+      } else {
+        this.setData({
+          innerWidth: '',
+          innerPaddingRight: '',
+          leftWidth: ''
+        })
+      }
+    },
     _showChange(show) {
       const animated = this.data.animated
       let displayStyle = ''


### PR DESCRIPTION
在旧版本的微信下，wx. getMenuButtonBoundingClientRect 接口获取到的某些结果为 0
因此修改了一下设置 navigation-bar 的样式的方法，如果获取到的 left 为 0，则再次获取，直到能够获取到并设置好为止