### PR TITLE
Update validator.ts

### DIFF
--- a/src/form/validator.ts
+++ b/src/form/validator.ts
@@ -121,6 +121,7 @@ export default {
     bytelength(r, value, param) {
         param = r.param
         // eslint-disable-next-line no-control-regex
+        value = value || ''
         const len = value.replace(/[^\x00-\xff]/g, '**').length
         if (len > param) {
             return sprintf(r.message || defaultMessage.bytelength, param)


### PR DESCRIPTION
在微信小程序中使用会报错
Uncaught (in promise) thirdScriptError
Cannot read property 'replace' of undefined
TypeError: Cannot read property 'replace' of undefined