### PR TITLE
<feat>: 让tabbar通过slot支持weui的icon组件。

### DIFF
--- a/src/tabbar/tabbar.ts
+++ b/src/tabbar/tabbar.ts
@@ -1,6 +1,7 @@
 Component({
     options: {
-        addGlobalClass: true
+        addGlobalClass: true,
+        multipleSlots: true
     },
     properties: {
         extClass: {

--- a/src/tabbar/tabbar.wxml
+++ b/src/tabbar/tabbar.wxml
@@ -2,7 +2,11 @@
   <!-- 选中的时候往 weui-tabbar__item 加 class:weui-bar__item_on -->
   <view data-index='{{index}}' bindtap="tabChange" wx:for="{{list}}" wx:key="index" class="weui-tabbar__item {{index === current ? 'weui-bar__item_on' : ''}}">
     <view style="position: relative;display:inline-block;">
-      <image src="{{current === index ? item.selectedIconPath : item.iconPath}}" class="weui-tabbar__icon"></image>
+      <view wx:if="{{item.slotIcon !=undefined ||item.selectSlotIcon != undefined}}" class="weui-tabbar__icon">
+        <slot wx:if="{{current !== index}}" name="{{item.slotIcon}}"></slot>
+        <slot wx:if="{{current === index}}" name="{{item.selectSlotIcon}}"></slot>
+      </view>
+      <image wx:else src="{{current === index ? item.selectedIconPath : item.iconPath}}" class="weui-tabbar__icon"></image>
       <mp-badge wx:if="{{item.badge || item.dot}}" content="{{item.badge}}" style="position: absolute;top:-2px;left:calc(100% - 3px)"></mp-badge>
     </view>
     <view class="weui-tabbar__label">{{item.text}}</view>

--- a/tools/demo/example/tabbar/tabbar.js
+++ b/tools/demo/example/tabbar/tabbar.js
@@ -7,6 +7,8 @@ CustomPage({
         list: [
             {
                 text: '微信',
+                slotIcon: "wx",
+                selectSlotIcon: "selwx",
                 iconPath: app.globalData.iconTabbar,
                 selectedIconPath: app.globalData.iconTabbar,
                 badge: '8'

--- a/tools/demo/example/tabbar/tabbar.json
+++ b/tools/demo/example/tabbar/tabbar.json
@@ -1,5 +1,6 @@
 {
   "usingComponents": {
-    "mp-tabbar": "../../components/tabbar/tabbar"
+    "mp-tabbar": "../../components/tabbar/tabbar",
+    "mp-icon": "../../components/icon/icon"
   }
 }

--- a/tools/demo/example/tabbar/tabbar.wxml
+++ b/tools/demo/example/tabbar/tabbar.wxml
@@ -3,5 +3,10 @@
         <view class="page__title">Tabbar</view>
         <view class="page__desc">类似小程序原生tabbar的组件，可用于自定义tabbar</view>
     </view>
-    <mp-tabbar class="tabbar" list="{{list}}" bindchange="tabChange"></mp-tabbar>
+    <mp-tabbar class="tabbar" list="{{list}}" bindchange="tabChange">
+        <block wx:for="{{list}}" wx:key="index">
+            <mp-icon slot="{{item.slotIcon}}" color="white" icon="add"></mp-icon>
+            <mp-icon slot="{{item.selectSlotIcon}}" color="green" icon="add"></mp-icon>
+        </block>
+    </mp-tabbar>
 </view>


### PR DESCRIPTION
目前tabbar的icon只支持图片，但是对于一些高级用法使用方希望使用icon组件。比如我。

目前weui内部icon组件很丰富。如果能让tabbar直接通过slot支持将会大大提高tabbar的可定制化能力。
