### PR TITLE
Let icon support custom sv

### DIFF
--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -41,7 +41,7 @@ Component({
     },
     methods: {
         _genSrcByIcon(v) {
-            this._genSrc(iconData[v][getFixedIconType(this.data.type)])
+            this._genSrc(/<svg .*>.*<\/svg>/.test(v) ? v : iconData[v][getFixedIconType(this.data.type)])
         },
         _genSrcByType(v) {
             const iconDataItem = iconData[this.data.icon]


### PR DESCRIPTION
考虑到官方提供的icon-list并不能完全满足所有需求；
为了避免开发者重复造轮，让mp-icon支持自定义svg；
既能达到icon风格上的一致，又能让开发者在使用&维护上达到一致。