### PR TITLE
fix(docs): fix useExtendedLib link #197

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ## WeUI组件库简介
 这是一套基于样式库[weui-wxss](https://github.com/Tencent/weui-wxss/)开发的小程序扩展组件库，同微信原生视觉体验一致的UI组件库，由微信官方设计团队和小程序团队为微信小程序量身设计，令用户的使用感知更加统一。
 
-> 支持[扩展库](/miniprogram/dev/reference/configuration/app.html#useExtendedLib)引入，不占用小程序包体积。
+> 支持[扩展库](https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#useExtendedLib)引入，不占用小程序包体积。
 
 ## 项目背景
 随着小程序的普及，微信也有很多内部小程序在开发，每个小程序都需要从零到1进行开发设计，而这个过程中，有大量的UI交互是重复的，另外，微信内部已经有一套H5版本的WeUI样式库。综合考虑，我们基于WeUI样式库开发了小程序版本的UI组件库，在内部多个小程序项目已经使用OK的情况下，我们把这套组件库开源让外部开发者也可以使用，欢迎大家Star以及提Issue。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@
 
 ## 引入组件
 
-1. 通过 [useExtendedLib 扩展库](../../reference/configuration/app.md#useExtendedLib) 的方式引入，这种方式引入的组件将不会计入代码包大小。
+1. 通过 [useExtendedLib 扩展库](https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#useExtendedLib) 的方式引入，这种方式引入的组件将不会计入代码包大小。
 2. 可以通过[npm](https://developers.weixin.qq.com/miniprogram/dev/devtools/npm.html)方式下载构建，npm包名为`weui-miniprogram`
 
 
@@ -14,7 +14,7 @@
 
 首先要在 app.wxss 里面引入 weui.wxss，如果是通过 npm 引入，需要先构建 npm（“工具”菜单 --> “构建 npm”）
 
-**通过 [useExtendedLib 扩展库](../../reference/configuration/app.md#useExtendedLib) 的方式引入，可省略 import 步骤**
+**通过 [useExtendedLib 扩展库](https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#useExtendedLib) 的方式引入，可省略 import 步骤**
 
 ```css
 @import 'weui-miniprogram/weui-wxss/dist/style/weui.wxss';


### PR DESCRIPTION
### 背景

- https://wechat-miniprogram.github.io/weui/docs/
- https://wechat-miniprogram.github.io/weui/docs/quickstart.html

在文档中浏览首页和快速上手时，想进一步了解 `useExtendedLib` ，发现对应的链接访问 404：

- https://wechat-miniprogram.github.io/weui/docs/reference/configuration/app.html#useExtendedLib

于是到小程序文档里[搜索 WeUI](https://developers.weixin.qq.com/doc/search.html?source=enter&query=WeUI&doc_type=miniprogram&jumpbackUrl=%2Fdoc%2F&timestamp=1651414277)，找到了 `weui-miniprogram` 的文档首页和 `useExtendedLib` 在小程序文档中对应的链接：

- https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/extended/weui/
- https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#useExtendedLib

### 改动

- 将文档中 `useExtendedLib` 相关的链接由相对路径改为绝对路径

### 相关 issue

#197 