### PR TITLE
fix(slideview): add judgment disable into touchmove and touchend

### DIFF
--- a/src/components/slideview/slideview.wxs
+++ b/src/components/slideview/slideview.wxs
@@ -14,7 +14,7 @@ var touchstart = function(event, ownerInstance) {
 var touchmove = function(event, ownerInstance) {
     var ins = event.instance
     var st = ins.getState()
-    if (!st.size || !st.isMoving) return
+    if (!st.size || !st.isMoving || st.disable) return
     // console.log('touchmove', JSON.stringify(event))
     var pagex = event.touches[0].pageX - st.startX
     var pagey = event.touches[0].pageY - st.startY
@@ -74,7 +74,7 @@ var touchmove = function(event, ownerInstance) {
 var touchend = function(event, ownerInstance) {
     var ins = event.instance
     var st = ins.getState()
-    if (!st.size || !st.isMoving) return
+    if (!st.size || !st.isMoving || st.disable) return
     // 左侧45度角为界限，大于45度则允许水平滑动
     if (st.firstAngle < 0) {
         return


### PR DESCRIPTION
当 slideview 绑定 `bindlongpress`，`bindlongpress` 激活后将 slideview 设置为 `disable=true` 仍旧可以左滑！

修复前：
<img src='https://user-images.githubusercontent.com/30423976/167692502-9ce3e87b-31df-4d0b-bb5f-cc1bf4910a59.gif' width='375'/>

修复后：
<img src='https://user-images.githubusercontent.com/30423976/167692527-31c36256-af8c-432f-8103-ec6944320072.gif' width='375'/>



