### PR TITLE
fix(components): 删除half-screen-dialog中最外层dom的catch:touchmove

### DIFF
--- a/src/components/half-screen-dialog/half-screen-dialog.ts
+++ b/src/components/half-screen-dialog/half-screen-dialog.ts
@@ -92,9 +92,6 @@ Component({
         buttonTap(e) {
             const { index } = e.currentTarget.dataset
             this.triggerEvent('buttontap', { index, item: this.data.buttons[index] }, {})
-        },
-        onMaskMouseMove() {
-            // do nothing
         }
     }
 })

--- a/src/components/half-screen-dialog/half-screen-dialog.wxml
+++ b/src/components/half-screen-dialog/half-screen-dialog.wxml
@@ -1,5 +1,5 @@
 <template name="body">
-  <view class="weui-half-screen-dialog {{innerShow ? 'weui-animate-slide-up' : 'weui-animate-slide-down' }} {{extClass}}" catch:touchmove="onMaskMouseMove">
+  <view class="weui-half-screen-dialog {{innerShow ? 'weui-animate-slide-up' : 'weui-animate-slide-down' }} {{extClass}}">
     <view class="weui-half-screen-dialog__hd">
       <view wx:if="{{closabled}}" class="weui-half-screen-dialog__hd__side" bindtap="close" data-type="close">
         <view class="weui-icon-btn" aria-role="button" hover-class="weui-active">


### PR DESCRIPTION
删除half-screen-dialog中最外层dom的catch:touchmove, 保证half-screen-dialog内部的textarea能正常滚动

related issue: #267 